### PR TITLE
some tests fail of micro-application-register under windows

### DIFF
--- a/micro-application-register/src/main/java/com/aol/micro/server/application/registry/Register.java
+++ b/micro-application-register/src/main/java/com/aol/micro/server/application/registry/Register.java
@@ -28,7 +28,7 @@ public class Register {
 		File dir = new File(config.getOutputDir(), "" + entry.getModule());
 		dir.mkdirs();
 
-		File file = new File(dir, entry.getHostname() + ":" + entry.getModule() + ":" + entry.getUuid());
+		File file = new File(dir, entry.getHostname() + "-" + entry.getModule() + "-" + entry.getUuid());
 		try {
 			FileUtils.writeStringToFile(file, JacksonUtil.serializeToJson(entry));
 		} catch (IOException e) {


### PR DESCRIPTION
File or folder name of windows system can‘t include characters: '/'  '?'  '*'  ':'  '|'  '\'  '<'  '>'
